### PR TITLE
Fix regexp in url_title

### DIFF
--- a/plugins/url_title.py
+++ b/plugins/url_title.py
@@ -6,7 +6,7 @@ import re
 
 def get_url_title(irc, user, target, line):
     regexp = re.compile(
-	r'^https?://'
+	r'https?://'
 	r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'
 	r'localhost|'
 	r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'


### PR DESCRIPTION
Currently url_title only fetches the title if the message starts with an URL.
This patch fixes the regexp to fetch url title even if it is not in the
beginning of the message