### PR TITLE
Fix url title regexp end

### DIFF
--- a/plugins/url_title.py
+++ b/plugins/url_title.py
@@ -6,13 +6,13 @@ import re
 
 def get_url_title(irc, user, target, line):
     regexp = re.compile(
-	r'https?://'
-	r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'
-	r'localhost|'
-	r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'
-	r'\[?[A-F0-9]*:[A-F0-9:]+\]?)'
-	r'(?::\d+)?'
-	r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+        r'https?://'
+        r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'
+        r'localhost|'
+        r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'
+        r'\[?[A-F0-9]*:[A-F0-9:]+\]?)'
+        r'(?::\d+)?'
+        r'(?:/?\S+)', re.IGNORECASE)
     urls = re.findall(regexp, line)
     for url in urls:
         page = fetcher.fetch_page(url)


### PR DESCRIPTION
First of all the '$' sign only allows pattern to match if there is nothing
after the url so let's remove that. Plus make the pattern a bit more simple.