### PR TITLE
Fix !a38 command and add language selection

### DIFF
--- a/plugins/a38.py
+++ b/plugins/a38.py
@@ -1,25 +1,51 @@
-import plugin
-import fetcher
+import requests
 from lxml import html
+
+import plugin
 
 
 def a38(irc, user, target, msg):
-    url = 'http://www.a38.hu/en/restaurant'
-    data = fetcher.get_page(url, 'a38.html')
-    tree = html.fromstring(data)
-    path = '//div[@class="foodCard__foodlist"]/text()'
+    _a38 = A38(_parse_language(msg))
+    irc.msg(target, _a38.fetch_todays_menu())
 
-    menu = tree.xpath(path)
-    if menu == []:
-        line = 'No menu found @ A38'
-        irc.msg(target, line)
-        return
 
-    menu = tree.xpath(path)
-    menu = ' | '.join(map(str.strip, menu))
+def _parse_language(msg):
+    argv = msg.split()
+    if len(argv) < 2:
+        return "en"
 
-    line = 'Current A38 menu: %s' % menu
-    irc.msg(target, line.encode('ascii', 'replace'))
+    return argv[1]
 
-plugin.add_plugin('^!a38\Z', a38)
-plugin.add_help('!a38', 'Query A-38 menu')
+
+class A38(object):
+    LANGUAGES = {
+        "hu": "https://www.a38.hu/hu/etterem",
+        "en": "https://www.a38.hu/en/restaurant"
+    }
+
+    def __init__(self, lang="en", **kwargs):
+        self.requests = kwargs.get('requests', requests)
+        self.url = A38.LANGUAGES.get(lang, A38.LANGUAGES["en"])
+
+    def fetch_todays_menu(self):
+        """
+        :rtype: str
+        """
+        response = self.requests.get(self.url)
+        tree = html.fromstring(response.content)
+
+        menu = tree.xpath('//div[@class="foodCard__foodlist"]/text()')  # type: list[str]
+
+        if not menu:
+            return 'No menu found @ A38'
+
+        return 'Current A38 menu: %s' % self.format_menu(menu)
+
+    def format_menu(self, menu):
+        return ' | '.join(
+            [dish.strip() for dish in menu if dish.strip() != ""]
+        )
+
+
+plugin.add_plugin('^!a38', a38)
+plugin.add_help('!a38', 'Query A-38 menu. For other languages, please add [en|hu]')

--- a/tests/a38/resources/a38_en.html
+++ b/tests/a38/resources/a38_en.html
@@ -1,0 +1,678 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>Restaurant - A38 Ship</title>
+    <meta name="title" content="Restaurant - A38 Ship">
+    <meta property="og:title" content="Restaurant - A38 Ship">
+    <meta name="robots" content="index, follow" />
+    <meta property="og:image" content="https://www.a38.hu/themes/a38/assets/images/frontend/postbanner.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_US">
+        <link rel="alternate" hreflang="hu" href="https://www.a38.hu/hu/etterem" />
+        <meta property="og:site_name" content="A38 Hajó">
+
+    <link rel="icon" type="image/x-icon" href="https://www.a38.hu/themes/a38/assets/images/favicon.ico">
+
+    <style>
+        .menuMain *{
+            color: #fff;
+        }
+        .menuMain-greedy{
+            display: none;
+        }
+    </style>
+
+    
+    <link href="https://www.a38.hu/themes/a38/assets/dist/css/plugins.css?id=154d76693fbe51fdebdd" rel="stylesheet">
+        <link href="https://www.a38.hu/themes/a38/assets/dist/css/main.min.css?id=6b1b04fccab11fac6df9" rel="stylesheet">
+    <!-- Facebook Pixel Code -->
+    <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '915667678515519');
+        fbq('track', 'PageView');
+    </script>
+    <noscript>
+        <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=915667678515519&ev=PageView&noscript=1" />
+    </noscript>
+    <!-- End Facebook Pixel Code -->
+
+</head>
+    <body data-resize="body" data-scroll="body">
+        <div class="ng-scope">
+            <!-- Header -->
+            <header id="layout-header">
+                <header class="l-siteHeader">
+
+    <div class="l-menuBar">
+        <div class="l-menuMain">
+            <nav class="menuMain">
+                <div class="menuMain-content layer layer--menu">
+                    <nav class="menuMain-greedy" data-equalizer>
+                        <div class="container" data-equalizer-watch>
+                            <div class="logo">
+                                <a href="/">
+                                                                        <img src="/themes/a38/assets/images/svgs/a38-logo.svg" height="40" alt="A38">
+                                                                    </a>
+                            </div>
+                            <div class="menuMain-content-lang">
+                                                                                                <a href="https://www.a38.hu/hu/etterem" class="btn btn--lang" title="Magyar verzió">HUN</a>
+                                                                                            </div>
+
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/en/programs" class="">Events</a></li>
+                                <li><a href="https://www.a38.hu/en/exhibition-space" class="">Exhibition space</a></li>
+                            </ul>
+                            <ul class="accordion menuMain-content-items" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item  active " data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Restaurant
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                            <li class=" active "><a href="https://www.a38.hu/en/restaurant">Actual</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/weekly-menu">Weekly menu</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/menu">Menu</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/beverages">Drinks</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/wine-list">Wine list</a></li>
+                                                                                    </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/en/bar" class="">Bar</a></li>
+                                <li><a href="https://www.a38.hu/en/galleries" class="">Galleries</a></li>
+                                <li><a href="https://www.a38.hu/en/tv" class="">Broadcasts</a></li>
+                                <li><a href="https://blog.a38.hu/" target="_blank">Blog</a></li>
+                                <li><a href="https://www.a38.hu/en/contact" class="">Contact</a></li>
+                            </ul>
+                            <br /><br />
+                            <ul class="accordion menuMain-content-items small" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        About us
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/en/history">History of A38 Ship</a></li>
+                                            <li><a href="https://www.a38.hu/en/colleagues">Colleagues</a></li>
+                                            <li><a href="https://www.a38.hu/en/stagecraft">Stagecraft</a></li>
+                                            <li><a href="https://www.a38.hu/en/informations">Information</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Services
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/en/event-management">Event management and renting</a></li>
+                                            <li><a href="https://www.a38.hu/en/a38-academy">A38 Academy</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <br />
+                            <ul class="socialBox">
+                                <li>
+                                    <a class="socialBox-item-facebook" href="https://www.facebook.com/a38.hajo" target="_blank"><span>facebook</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-youtube" href="https://www.youtube.com/user/A38Captain" target="_blank"><span>youtube</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-instagram" href="https://www.instagram.com/a38ship/" target="_blank"><span>instagram</span></a>
+                                </li>
+                            </ul>
+
+                            <a href="#" class="menuMain-hiddenMenuToggler hidden"></a>
+
+                        </div>
+                        <header data-equalizer-watch>
+                            <a class="layer-close" href="javascript:void(0)"><span>Back</span></a>
+                        </header>
+                    </nav>
+
+                </div>
+            </nav>
+        </div>
+    </div>
+
+    <div id="header-user">
+        <header class="mobileTopBar">
+    <div class="mobileTopBar__togglerBlock">
+        <a class="js-menutoggler" href="javascript:;" onclick="A38.Layout.layerOpen('.menuMain-content', true)">
+            <span>
+                                    MENU
+                            </span>
+        </a>
+    </div>
+    <div class="mobileTopBar__logoBlock">
+        <a href="/">
+                        <img src="/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="40" alt="A38">
+                    </a>
+    </div>
+    <div class="mobileTopBar__userBlock">
+                    <a href="https://www.a38.hu/en/login" data-request="onPopupLogin" class="mobileTopBar__userBlock__login"><span>Login</span></a>
+            </div>
+    <div class="mobileTopBar__searchBlock">
+        <div id="search">
+    <div class="icon" title="Search">
+        <span>Search</span>
+    </div>
+    <div class="layer"></div>
+    <div class="container">
+        <div class="main">
+            <form method="GET" action="https://www.a38.hu/en/search">
+                <label>
+                    <input type="text" name="s" class="searchinput"
+                           placeholder="Search ..."/>
+                    <button type="button" class="clear hide-for-large" title="Clear">
+                        <span>Clear</span>
+                    </button>
+                    <span class="oc-loading"></span>
+                </label>
+                <button type="submit"
+                        class="show-for-large btn btn-small">Search</button>
+                <button type="button" class="searchclose show-for-xlarge"
+                        title="Close">
+                    <span>Close</span></button>
+            </form>
+        </div>
+    </div>
+</div>    </div>
+</header>    </div>
+
+</header>            </header>
+            <div class="l-content">
+                <!-- Content -->
+                <section id="layout-content">
+                                        <div class="container">
+    </div>                    <div class="l-content-inner">
+    <header class="mastHead">
+    <!-- Aspect Ratio 4x1 -->
+    <img class="mastHead__bg"
+         src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif"
+         data-interchange="[https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, small],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, medium],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, large],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, xlarge]"
+         alt="Restaurant">
+    <div class="mastHead__content">
+        <div class="l-constrained">
+            <h1 class="mastHead__title">
+                <a href="https://www.a38.hu/en/restaurant">Restaurant</a>
+            </h1>
+        </div>
+    </div>
+</header>
+    <section class="restaurantHeadNav">
+    <div class="l-constrainedGrid">
+        <nav class="restaurantNav tabNav">
+            <ul class="tabNav-menu" role="navigation">
+                <li class=" active "><a href="https://www.a38.hu/en/restaurant">Actual</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/weekly-menu">Weekly menu</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/menu">Menu</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/beverages">Drinks</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/wine-list">Wine list</a></li>
+                            </ul>
+        </nav>
+    </div>
+</section>
+    <div class="l-constrainedGrid l-gutterSection">
+    <div class="row">
+        <div class="columns">
+            <!-- <h1 class=''>Étterem</h1> -->
+            <div class="row">
+                <div class="columns large-4 xlarge-3">
+                    <div class="infoCard">
+                        <figure class="infoCard__fig">
+                            <img class="infoCard__fig__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.png" alt="">
+                            <a href="#" class="infoCard__fig__overlay">
+                                <img class="infoCard__fig__logo" src="https://www.a38.hu/themes/a38/assets/images/frontend/logo_a38_etterem_hu.png" alt="">
+                            </a>
+                        </figure>
+                        <div class="infoCard__caption">
+                            <p><strong>Opening hours:</strong><br>
+                                Mon-Sat 11-23h
+                            </p>
+
+
+                            <p><strong>Kitchen is open:</strong><br>
+                                Mon-Sat 12-22h
+                            </p>
+
+                            <p><strong>Reservation:</strong><br>
+                                Phone: <a href="tel:003614643946">+36-1-464-39-46</a><br>
+                                Email: <a href="mailto:etterem@a38.hu">etterem@a38.hu</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="columns large-8 xlarge-9">
+
+                        
+    
+        <div class="foodCard">
+            <figure class="foodCard__photo">
+                <a href="https://www.a38.hu/en/restaurant/weekly-menu">
+                                            <img src="https://www.a38.hu/themes/a38/assets/images/frontend/placeholder.jpg" alt="January 31. Thursday">
+                                    </a>
+            </figure>
+
+            <section class="foodCard__details">
+                <header>
+                    <a href="https://www.a38.hu/en/restaurant/weekly-menu"
+                       class="foodCard__label">Weekly menu
+                    </a>
+
+                    <h2 class="foodCard__title">January 31. Thursday</h2>
+
+                    <p class="foodCard__disclaimer">
+                        Every weekday between 12:00 and 15:00 two course menu offer for 1300 HUF or three courses with dessert for 1500 HUF
+                    </p>
+                </header>
+                <div class="foodCard__foodlist">
+                    Cauliflower soup<br />
+Fried breaded pork with corn rice<br />
+Vegetarian: Fried curd cheese with corn rice<br />
+Tiramisu
+                </div>
+            </section>
+        </div>
+
+    
+                                    </div>
+            </div>
+
+                        <section id="restEvents" class="restEvents l-gutterSection">
+
+                <div class="l-gutterSection">
+    <section id="exhibEvents" class="exhibEvents l-gutterSection">
+        <header class="listHeader">
+            <h2 class="listHeader__title">
+                                    Programs in the Restaurant
+                            </h2>
+        </header>
+        <ul id="eventList" class="list list--ofcards">
+
+                
+<li>
+    <a href="https://www.a38.hu/en/program/rajatszas-special-grecsokollar-hu"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/en/program/rajatszas-special-grecsokollar-hu">
+        <meta itemprop="startDate" content="2019-02-11T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                February
+                            </div>
+                            <div class="dateBox-item-day">11</div>
+                            <div >Monday <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">Restaurant</span>
+                                <link itemprop="address" content="Budapest - A38 Restaurant" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg" alt="Rájátszás Special - GreCSÓKOLlár">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Rájátszás Special - GreCSÓKOLlár
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                        </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>The new series of the A38 Ship titled Beats &amp; Bites held at the A38 will feature the duo of GreCSÓKOLlár, it is the singer-songwriter László Kollár-Klemencz and poet Krisztián Grecsó.</p>
+            </div>
+                    </section>
+            </a>
+</li>    
+<li>
+    <a href="https://www.a38.hu/en/program/harcsa-veronika-gyemant-balint-duo-hu-16215"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/en/program/harcsa-veronika-gyemant-balint-duo-hu-16215">
+        <meta itemprop="startDate" content="2019-02-25T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                February
+                            </div>
+                            <div class="dateBox-item-day">25</div>
+                            <div >Monday <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">Restaurant</span>
+                                <link itemprop="address" content="Budapest - A38 Restaurant" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg" alt="Harcsa Veronika-Gyémánt Bálint duo">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Harcsa Veronika-Gyémánt Bálint duo
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                                <li>
+                            <span class="tag ">Jazz</span>
+                        </li>
+                                    </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>Our new serie titled Beats &amp; Bites - which is held at our restaurant with special Danube panorama - will present the duo of singer Veronika Harcsa and guitarist Bálint Gyémánt.</p>
+            </div>
+                    </section>
+            </a>
+</li>
+        </ul>
+
+        <div id="eventListBtn">
+                    </div>
+    </section>
+</div>
+
+
+            </section>
+                    </div>
+    </div>
+</div></div>                </section>
+                <!-- Footer -->
+                <footer id="layout-footer">
+                    <footer class="l-siteFooter">
+    <div class="l-footerLogos">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-7 large-8 column">
+                    <ul class="logoList logoList--left">
+                        <li><a href="http://teh.net/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/teh-logo@2x.png" alt="Trans Europe Halles" title="Trans Europe Halles"></a></li>
+                        <li><a href="https://liveurope.eu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/liveeurope-logo@2x.png" alt="Live Europe" title="Live Europe"></a></li>
+                        <li><a href="https://ec.europa.eu/programmes/creative-europe/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/creative_europe@2x.png" alt="Creative Europe Programme" title="Creative Europe Programme"></a></li>
+                        <li class="linebreak"></li>
+                        <li><a href="https://www.mediaklikk.hu/m2/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/m2petofi-logo@2x.png" alt="m2 Petőfi" title="m2 Petőfi"></a></li>
+                        <li><a href="https://halmosbelaprogram.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/hbp-logo@2x.png" alt="Halmos Béla Program" title="Halmos Béla Program"></a></li>
+                    </ul>
+                </div>
+                <div class="small-5 large-4 column">
+                    <ul class="logoList logoList--right">
+                        <li><a href="https://www.barion.com/hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/barion-logo@2x.png" alt="Barion" title="Barion"></a></li>
+                        <li><a href="https://www.mastercard.hu/hu-hu.html" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/mastercard-logo@2x.png" alt="Mastercard" title="Mastercard"></a></li>
+                        <li><a href="https://www.visa.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/visa-logo@2x.png" alt="VISA" title="VISA"></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            A38 Ship Budapest
+                                                    </h2>
+                        <p>
+                                                            Petőfi bridge, Buda side
+                                                        <br>
+                            <a href="mailto:info@a38.hu">info@a38.hu</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Tickets & Information
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643940">
+                                                                    +36-1-464-39-40
+                                                            </a><br>
+                                                            Mon-Sun 8-22h or until the end of events
+                                                    </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Restaurant
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643946">
+                                                                    +36-1-464-39-46
+                                                            </a><br>
+
+                                                            Mon-Sat: 11-23h
+                                                    </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon footerBottom">
+        <div class="l-constrainedGrid">
+            <div class="row align-middle">
+                <div class="small-12 medium-8 column text-left text-mobile-center">
+                    <div class="">
+                                                <a href="/"><img src="https://www.a38.hu/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="30" alt="A38"></a>
+                                            </div>
+                    <br />
+                    <p class="footerPolicy">
+                                            <strong>The above hours are only directions that may differ due to weather conditions or other unforeseen circumstances.</strong><br>
+                        By entering the A38 Ship visitors consent to be filmed which may be used for public broadcast or promotional purposes.
+                                            <br/>
+                        <a href="https://www.a38.hu/en/house-rule">Rules & Policies</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/en/privacy-policy">Privacy policy</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/en/imprint">Imprint</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>                </footer>
+            </div>
+        </div>
+
+        <!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                      <div class="pswp__preloader__cut">
+                        <div class="pswp__preloader__donut"></div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+    <!-- Scripts -->
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/plugins.js?id=fdf9b716630fc1d86d4e"></script>
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/app.js?id=546091324477dcf15fd7"></script>
+
+<script src="/modules/system/assets/js/framework.js"></script>
+<script src="/modules/system/assets/js/framework.extras.js"></script>
+<link rel="stylesheet" property="stylesheet" href="/modules/system/assets/css/framework.extras.css">
+<!-- Load Facebook SDK for JavaScript -->
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=173023849958325&autoLogAppEvents=1';
+    fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-4369219-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-4369219-1', {
+        'custom_map': {
+            'dimension1': 'user-login-type',
+            'dimension2': 'authenticated',
+            'dimension3': 'lang'
+        },
+        'user-login-type': 'user-no-login'
+    });
+
+    A38.Locale.init('en', 'HUF');
+    A38.Locale.setTranslations({"a38.core::lang.gallery.photo":"Photo","a38.core::lang.gallery.share_with_fb":"Share with Facebook","a38.core::lang.gallery.download":"Download photo"});
+    A38.Log.init();
+</script>
+<!-- Hotjar Tracking Code for www.a38.hu -->
+<script>
+(function(h,o,t,j,a,r){
+    h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+    h._hjSettings={hjid:346160,hjsv:6};
+    a=o.getElementsByTagName('head')[0];
+    r=o.createElement('script');r.async=1;
+    r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+    a.appendChild(r);
+})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>
+        $(document).ready(function() {
+            new A38.EventList($('#eventList'));
+        });
+    </script>
+<div id="ajax-popup" class="reveal" data-reveal data-animation-in="slide-in-up" data-animation-out="slide-out-down">
+    <div id="ajax-popup-stage">
+        <div id="ajax-popup-content" class="popup-column"></div>
+        <div id="ajax-popup-prev" class="popup-column"></div>
+        <div id="ajax-popup-next" class="popup-column"></div>
+    </div>
+</div>
+
+<script>
+    window.addEventListener("load", function(){
+        window.cookieconsent.initialise({
+            "palette": {
+                "popup": {
+                    "background": "#f8f8f8",
+                    "text": "#838391"
+                },
+                "button": {
+                    "background": "#D90016"
+                }
+            },
+            "showLink": true,
+            "theme": "classic",
+            "content": {
+                "message": "We\x20use\x20cookies\x20to\x20create\x20the\x20most\x20secure\x20and\x20effective\x20website\x20for\x20our\x20customers.\x20By\x20using\x20the\x20site\x20you\x20give\x20consent\x20to\x20this.",
+                "dismiss": "Got\x20it\x21",
+                "link": "Learn more",
+                "href": "https://www.a38.hu/en/privacy-policy"
+            }
+        })});
+</script>    </body>
+</html>

--- a/tests/a38/resources/a38_hu.html
+++ b/tests/a38/resources/a38_hu.html
@@ -1,0 +1,679 @@
+<!DOCTYPE html>
+<html lang="hu">
+    <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>Étterem - A38 Hajó</title>
+    <meta name="title" content="Étterem - A38 Hajó">
+    <meta property="og:title" content="Étterem - A38 Hajó">
+    <meta name="robots" content="index, follow" />
+    <meta property="og:image" content="https://www.a38.hu/themes/a38/assets/images/frontend/postbanner.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="hu_HU">
+        <link rel="alternate" hreflang="en" href="https://www.a38.hu/en/restaurant" />
+        <meta property="og:site_name" content="A38 Hajó">
+
+    <link rel="icon" type="image/x-icon" href="https://www.a38.hu/themes/a38/assets/images/favicon.ico">
+
+    <style>
+        .menuMain *{
+            color: #fff;
+        }
+        .menuMain-greedy{
+            display: none;
+        }
+    </style>
+
+    
+    <link href="https://www.a38.hu/themes/a38/assets/dist/css/plugins.css?id=154d76693fbe51fdebdd" rel="stylesheet">
+        <link href="https://www.a38.hu/themes/a38/assets/dist/css/main.min.css?id=6b1b04fccab11fac6df9" rel="stylesheet">
+    <!-- Facebook Pixel Code -->
+    <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '915667678515519');
+        fbq('track', 'PageView');
+    </script>
+    <noscript>
+        <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=915667678515519&ev=PageView&noscript=1" />
+    </noscript>
+    <!-- End Facebook Pixel Code -->
+
+</head>
+    <body data-resize="body" data-scroll="body">
+        <div class="ng-scope">
+            <!-- Header -->
+            <header id="layout-header">
+                <header class="l-siteHeader">
+
+    <div class="l-menuBar">
+        <div class="l-menuMain">
+            <nav class="menuMain">
+                <div class="menuMain-content layer layer--menu">
+                    <nav class="menuMain-greedy" data-equalizer>
+                        <div class="container" data-equalizer-watch>
+                            <div class="logo">
+                                <a href="/">
+                                                                        <img src="/themes/a38/assets/images/svgs/a38-logo.svg" height="40" alt="A38">
+                                                                    </a>
+                            </div>
+                            <div class="menuMain-content-lang">
+                                                                                                <a href="https://www.a38.hu/en/restaurant" class="btn btn--lang" title="English version">ENG</a>
+                                                                                            </div>
+
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/hu/programok" class="">Programok</a></li>
+                                <li><a href="https://www.a38.hu/hu/kiallitoter" class="">Kiállítótér</a></li>
+                            </ul>
+                            <ul class="accordion menuMain-content-items" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item  active " data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Étterem
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                            <li class=" active "><a href="https://www.a38.hu/hu/etterem">Aktuális</a></li>
+                                            <li class=""><a href="https://www.a38.hu/hu/etterem/heti-menu">Heti menü</a></li>
+                                            <li class=""><a href="https://www.a38.hu/hu/etterem/etlap">Étlap</a></li>
+                                            <li class=""><a href="https://www.a38.hu/hu/etterem/itallap">Itallap</a></li>
+                                            <li class=""><a href="https://www.a38.hu/hu/etterem/borlap">Bor- és koktéllap</a></li>
+                                                                                    </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/hu/bar" class="">Bár</a></li>
+                                <li><a href="https://www.a38.hu/hu/galeriak" class="">Galériák</a></li>
+                                <li><a href="https://www.a38.hu/hu/tv" class="">Adások</a></li>
+                                <li><a href="https://blog.a38.hu/" target="_blank">Blog</a></li>
+                                <li><a href="https://www.a38.hu/hu/kapcsolat" class="">Kapcsolat</a></li>
+                            </ul>
+                            <br /><br />
+                            <ul class="accordion menuMain-content-items small" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        A38-ról
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/hu/tortenet">A38 Hajó története</a></li>
+                                            <li><a href="https://www.a38.hu/hu/munkatarsak">Munkatársak</a></li>
+                                            <li><a href="https://www.a38.hu/hu/szinpadtechnika">Színpadtechnika</a></li>
+                                            <li><a href="https://www.a38.hu/hu/informaciok">Információk</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Szolgáltatások
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/hu/rendezvenyszervezes">Rendezvényszervezés és terembérlés</a></li>
+                                            <li><a href="https://www.a38.hu/hu/a38-akademia">A38 Akadémia</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <br />
+                            <ul class="socialBox">
+                                <li>
+                                    <a class="socialBox-item-facebook" href="https://www.facebook.com/a38.hajo" target="_blank"><span>facebook</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-youtube" href="https://www.youtube.com/user/A38Captain" target="_blank"><span>youtube</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-instagram" href="https://www.instagram.com/a38ship/" target="_blank"><span>instagram</span></a>
+                                </li>
+                            </ul>
+
+                            <a href="#" class="menuMain-hiddenMenuToggler hidden"></a>
+
+                        </div>
+                        <header data-equalizer-watch>
+                            <a class="layer-close" href="javascript:void(0)"><span>Vissza</span></a>
+                        </header>
+                    </nav>
+
+                </div>
+            </nav>
+        </div>
+    </div>
+
+    <div id="header-user">
+        <header class="mobileTopBar">
+    <div class="mobileTopBar__togglerBlock">
+        <a class="js-menutoggler" href="javascript:;" onclick="A38.Layout.layerOpen('.menuMain-content', true)">
+            <span>
+                                    MENÜ
+                            </span>
+        </a>
+    </div>
+    <div class="mobileTopBar__logoBlock">
+        <a href="/">
+                        <img src="/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="40" alt="A38">
+                    </a>
+    </div>
+    <div class="mobileTopBar__userBlock">
+                    <a href="https://www.a38.hu/hu/belepes" data-request="onPopupLogin" class="mobileTopBar__userBlock__login"><span>Belépés</span></a>
+            </div>
+    <div class="mobileTopBar__searchBlock">
+        <div id="search">
+    <div class="icon" title="Keresés">
+        <span>Keresés</span>
+    </div>
+    <div class="layer"></div>
+    <div class="container">
+        <div class="main">
+            <form method="GET" action="https://www.a38.hu/hu/kereses">
+                <label>
+                    <input type="text" name="s" class="searchinput"
+                           placeholder="Keresés ..."/>
+                    <button type="button" class="clear hide-for-large" title="Törlés">
+                        <span>Törlés</span>
+                    </button>
+                    <span class="oc-loading"></span>
+                </label>
+                <button type="submit"
+                        class="show-for-large btn btn-small">Keresés</button>
+                <button type="button" class="searchclose show-for-xlarge"
+                        title="Bezár">
+                    <span>Bezár</span></button>
+            </form>
+        </div>
+    </div>
+</div>    </div>
+</header>    </div>
+
+</header>            </header>
+            <div class="l-content">
+                <!-- Content -->
+                <section id="layout-content">
+                                        <div class="container">
+    </div>                    <div class="l-content-inner">
+    <header class="mastHead">
+    <!-- Aspect Ratio 4x1 -->
+    <img class="mastHead__bg"
+         src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif"
+         data-interchange="[https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, small],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, medium],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, large],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, xlarge]"
+         alt="Étterem">
+    <div class="mastHead__content">
+        <div class="l-constrained">
+            <h1 class="mastHead__title">
+                <a href="https://www.a38.hu/hu/etterem">Étterem</a>
+            </h1>
+        </div>
+    </div>
+</header>
+    <section class="restaurantHeadNav">
+    <div class="l-constrainedGrid">
+        <nav class="restaurantNav tabNav">
+            <ul class="tabNav-menu" role="navigation">
+                <li class=" active "><a href="https://www.a38.hu/hu/etterem">Aktuális</a></li>
+                <li class=""><a href="https://www.a38.hu/hu/etterem/heti-menu">Heti menü</a></li>
+                <li class=""><a href="https://www.a38.hu/hu/etterem/etlap">Étlap</a></li>
+                <li class=""><a href="https://www.a38.hu/hu/etterem/itallap">Itallap</a></li>
+                <li class=""><a href="https://www.a38.hu/hu/etterem/borlap">Bor- és koktéllap</a></li>
+                            </ul>
+        </nav>
+    </div>
+</section>
+    <div class="l-constrainedGrid l-gutterSection">
+    <div class="row">
+        <div class="columns">
+            <!-- <h1 class=''>Étterem</h1> -->
+            <div class="row">
+                <div class="columns large-4 xlarge-3">
+                    <div class="infoCard">
+                        <figure class="infoCard__fig">
+                            <img class="infoCard__fig__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.png" alt="">
+                            <a href="#" class="infoCard__fig__overlay">
+                                <img class="infoCard__fig__logo" src="https://www.a38.hu/themes/a38/assets/images/frontend/logo_a38_etterem_hu.png" alt="">
+                            </a>
+                        </figure>
+                        <div class="infoCard__caption">
+                            <p><strong>Nyitvatartás:</strong><br>
+                                H-Szo 11-23h
+                            </p>
+
+
+                            <p><strong>Konyha nyitvatartása:</strong><br>
+                                H-Szo 12-22h
+                            </p>
+
+                            <p><strong>Asztalfoglalás:</strong><br>
+                                Telefon: <a href="tel:003614643946">(06 1) 464 39 46</a><br>
+                                Email: <a href="mailto:etterem@a38.hu">etterem@a38.hu</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="columns large-8 xlarge-9">
+
+                        
+    
+        <div class="foodCard">
+            <figure class="foodCard__photo">
+                <a href="https://www.a38.hu/hu/etterem/heti-menu">
+                                            <img src="https://www.a38.hu/themes/a38/assets/images/frontend/placeholder.jpg" alt="január 31. csütörtök">
+                                    </a>
+            </figure>
+
+            <section class="foodCard__details">
+                <header>
+                    <a href="https://www.a38.hu/hu/etterem/heti-menu"
+                       class="foodCard__label">Heti menü
+                    </a>
+
+                    <h2 class="foodCard__title">január 31. csütörtök</h2>
+
+                    <p class="foodCard__disclaimer">
+                        Minden hétköznap 12 és 15 óra között két fogás 1300 Ft-ért, vagy 3 fogás 1500 Ft-ért
+                    </p>
+                </header>
+                <div class="foodCard__foodlist">
+                    Karfiolleves<br />
+Lenmagos rántott karaj kukoricás rizzsel<br />
+Vegetáriánus: Lenmagos rántott sajt kukoricás rizzsel<br />
+Tiramisu<br />
+
+                </div>
+            </section>
+        </div>
+
+    
+                                    </div>
+            </div>
+
+                        <section id="restEvents" class="restEvents l-gutterSection">
+
+                <div class="l-gutterSection">
+    <section id="exhibEvents" class="exhibEvents l-gutterSection">
+        <header class="listHeader">
+            <h2 class="listHeader__title">
+                                    Programok az étteremben
+                            </h2>
+        </header>
+        <ul id="eventList" class="list list--ofcards">
+
+                
+<li>
+    <a href="https://www.a38.hu/hu/program/rajatszas-special-grecsokollar-hu"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/hu/program/rajatszas-special-grecsokollar-hu">
+        <meta itemprop="startDate" content="2019-02-11T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                február
+                            </div>
+                            <div class="dateBox-item-day">11</div>
+                            <div >hétfő <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">étterem</span>
+                                <link itemprop="address" content="Budapest - A38 étterem" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg" alt="Rájátszás Special - GreCSÓKOLlár">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Rájátszás Special - GreCSÓKOLlár
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                        </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>Új sorozatunk, a Beats &amp; Bites - melynek helyszíne a különleges dunai panorámával rendelkező éttermünk - első fellépője a Kollár-Klemencz László énekes-dalszerző és Grecsó Krisztián költő duója lesz.</p>
+            </div>
+                    </section>
+            </a>
+</li>    
+<li>
+    <a href="https://www.a38.hu/hu/program/harcsa-veronika-gyemant-balint-duo-hu-16215"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/hu/program/harcsa-veronika-gyemant-balint-duo-hu-16215">
+        <meta itemprop="startDate" content="2019-02-25T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                február
+                            </div>
+                            <div class="dateBox-item-day">25</div>
+                            <div >hétfő <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">étterem</span>
+                                <link itemprop="address" content="Budapest - A38 étterem" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg" alt="Harcsa Veronika-Gyémánt Bálint duó">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Harcsa Veronika-Gyémánt Bálint duó
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                                <li>
+                            <span class="tag ">Jazz</span>
+                        </li>
+                                    </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>Új sorozatunk, a Beats &amp; Bites - melynek helyszíne a különleges dunai panorámával rendelkező éttermünk - fellépője ezúttal Harcsa Veronika énekesnő és Gyémánt Bálint gitárművész duója lesz.</p>
+            </div>
+                    </section>
+            </a>
+</li>
+        </ul>
+
+        <div id="eventListBtn">
+                    </div>
+    </section>
+</div>
+
+
+            </section>
+                    </div>
+    </div>
+</div></div>                </section>
+                <!-- Footer -->
+                <footer id="layout-footer">
+                    <footer class="l-siteFooter">
+    <div class="l-footerLogos">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-7 large-8 column">
+                    <ul class="logoList logoList--left">
+                        <li><a href="http://teh.net/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/teh-logo@2x.png" alt="Trans Europe Halles" title="Trans Europe Halles"></a></li>
+                        <li><a href="https://liveurope.eu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/liveeurope-logo@2x.png" alt="Live Europe" title="Live Europe"></a></li>
+                        <li><a href="https://ec.europa.eu/programmes/creative-europe/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/creative_europe@2x.png" alt="Creative Europe Programme" title="Creative Europe Programme"></a></li>
+                        <li class="linebreak"></li>
+                        <li><a href="https://www.mediaklikk.hu/m2/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/m2petofi-logo@2x.png" alt="m2 Petőfi" title="m2 Petőfi"></a></li>
+                        <li><a href="https://halmosbelaprogram.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/hbp-logo@2x.png" alt="Halmos Béla Program" title="Halmos Béla Program"></a></li>
+                    </ul>
+                </div>
+                <div class="small-5 large-4 column">
+                    <ul class="logoList logoList--right">
+                        <li><a href="https://www.barion.com/hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/barion-logo@2x.png" alt="Barion" title="Barion"></a></li>
+                        <li><a href="https://www.mastercard.hu/hu-hu.html" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/mastercard-logo@2x.png" alt="Mastercard" title="Mastercard"></a></li>
+                        <li><a href="https://www.visa.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/visa-logo@2x.png" alt="VISA" title="VISA"></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            A38 Hajó Budapest
+                                                    </h2>
+                        <p>
+                                                            Petőfi híd, budai hídfő
+                                                        <br>
+                            <a href="mailto:info@a38.hu">info@a38.hu</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Jegypénztár / Infopult
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643940">
+                                                                    (06 1) 464 39 40
+                                                            </a><br>
+                                                            H-V: 8-22h ill. programzárásig
+                                                    </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Étterem
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643946">
+                                                                    (06 1) 464 39 46
+                                                            </a><br>
+
+                                                            H-Szo: 11-23h
+                                                    </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon footerBottom">
+        <div class="l-constrainedGrid">
+            <div class="row align-middle">
+                <div class="small-12 medium-8 column text-left text-mobile-center">
+                    <div class="">
+                                                <a href="/"><img src="https://www.a38.hu/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="30" alt="A38"></a>
+                                            </div>
+                    <br />
+                    <p class="footerPolicy">
+                                            <strong>A nyitvatartási információk tájékoztató jellegűek. A programváltoztatás jogát fenntartjuk.</strong><br>
+                        Az A38 hajó területére való belépéssel hozzájárulsz, hogy rólad a közönség részeként felvétel készüljön, és ez a felvétel nyilvánosságot kapjon.
+                                            <br/>
+                        <a href="https://www.a38.hu/hu/hazirend">Házirend</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/hu/adatvedelem">Adatvédelem</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/hu/impresszum">Impresszum</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>                </footer>
+            </div>
+        </div>
+
+        <!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Bezárás (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Megosztás"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Váltás teljesképernyőre"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Nagyítás (+/-)"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                      <div class="pswp__preloader__cut">
+                        <div class="pswp__preloader__donut"></div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Előző (balra)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Következő (jobbra)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+    <!-- Scripts -->
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/plugins.js?id=fdf9b716630fc1d86d4e"></script>
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/app.js?id=546091324477dcf15fd7"></script>
+
+<script src="/modules/system/assets/js/framework.js"></script>
+<script src="/modules/system/assets/js/framework.extras.js"></script>
+<link rel="stylesheet" property="stylesheet" href="/modules/system/assets/css/framework.extras.css">
+<!-- Load Facebook SDK for JavaScript -->
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = 'https://connect.facebook.net/hu_HU/sdk.js#xfbml=1&version=v2.12&appId=173023849958325&autoLogAppEvents=1';
+    fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-4369219-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-4369219-1', {
+        'custom_map': {
+            'dimension1': 'user-login-type',
+            'dimension2': 'authenticated',
+            'dimension3': 'lang'
+        },
+        'user-login-type': 'user-no-login'
+    });
+
+    A38.Locale.init('hu', 'Ft');
+    A38.Locale.setTranslations({"a38.core::lang.gallery.photo":"Fot\u00f3","a38.core::lang.gallery.share_with_fb":"Megoszt\u00e1s Facebookon","a38.core::lang.gallery.download":"K\u00e9p let\u00f6lt\u00e9se"});
+    A38.Log.init();
+</script>
+<!-- Hotjar Tracking Code for www.a38.hu -->
+<script>
+(function(h,o,t,j,a,r){
+    h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+    h._hjSettings={hjid:346160,hjsv:6};
+    a=o.getElementsByTagName('head')[0];
+    r=o.createElement('script');r.async=1;
+    r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+    a.appendChild(r);
+})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>
+        $(document).ready(function() {
+            new A38.EventList($('#eventList'));
+        });
+    </script>
+<div id="ajax-popup" class="reveal" data-reveal data-animation-in="slide-in-up" data-animation-out="slide-out-down">
+    <div id="ajax-popup-stage">
+        <div id="ajax-popup-content" class="popup-column"></div>
+        <div id="ajax-popup-prev" class="popup-column"></div>
+        <div id="ajax-popup-next" class="popup-column"></div>
+    </div>
+</div>
+
+<script>
+    window.addEventListener("load", function(){
+        window.cookieconsent.initialise({
+            "palette": {
+                "popup": {
+                    "background": "#f8f8f8",
+                    "text": "#838391"
+                },
+                "button": {
+                    "background": "#D90016"
+                }
+            },
+            "showLink": true,
+            "theme": "classic",
+            "content": {
+                "message": "Az\x20A38\x20Haj\u00F3\x20weboldal\u00E1n\x20cookie\x2Dkat\x20\x28s\u00FCtiket\x29\x20haszn\u00E1lunk\x20az\u00E9rt,\x20hogy\x20az\x20oldal\x20haszn\u00E1lata\x20sor\u00E1n\x20a\x20lehet\u0151\x20legbiztons\u00E1gosabb\x20\u00E9s\x20legjobb\x20\u00E9lm\u00E9nyt\x20tudjuk\x20biztos\u00EDtani.\x20Az\x20oldal\x20haszn\u00E1lat\u00E1val\x20hozz\u00E1j\u00E1rulsz\x20ehhez.",
+                "dismiss": "\u00C9rtem\x21",
+                "link": "Részletek",
+                "href": "https://www.a38.hu/hu/adatvedelem"
+            }
+        })});
+</script>    </body>
+</html>

--- a/tests/a38/resources/no_menu.html
+++ b/tests/a38/resources/no_menu.html
@@ -1,0 +1,646 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <title>Restaurant - A38 Ship</title>
+    <meta name="title" content="Restaurant - A38 Ship">
+    <meta property="og:title" content="Restaurant - A38 Ship">
+    <meta name="robots" content="index, follow" />
+    <meta property="og:image" content="https://www.a38.hu/themes/a38/assets/images/frontend/postbanner.jpg">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_US">
+        <link rel="alternate" hreflang="hu" href="https://www.a38.hu/hu/etterem" />
+        <meta property="og:site_name" content="A38 Hajó">
+
+    <link rel="icon" type="image/x-icon" href="https://www.a38.hu/themes/a38/assets/images/favicon.ico">
+
+    <style>
+        .menuMain *{
+            color: #fff;
+        }
+        .menuMain-greedy{
+            display: none;
+        }
+    </style>
+
+    
+    <link href="https://www.a38.hu/themes/a38/assets/dist/css/plugins.css?id=154d76693fbe51fdebdd" rel="stylesheet">
+        <link href="https://www.a38.hu/themes/a38/assets/dist/css/main.min.css?id=6b1b04fccab11fac6df9" rel="stylesheet">
+    <!-- Facebook Pixel Code -->
+    <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+            n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+            if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+            n.queue=[];t=b.createElement(e);t.async=!0;
+            t.src=v;s=b.getElementsByTagName(e)[0];
+            s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '915667678515519');
+        fbq('track', 'PageView');
+    </script>
+    <noscript>
+        <img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=915667678515519&ev=PageView&noscript=1" />
+    </noscript>
+    <!-- End Facebook Pixel Code -->
+
+</head>
+    <body data-resize="body" data-scroll="body">
+        <div class="ng-scope">
+            <!-- Header -->
+            <header id="layout-header">
+                <header class="l-siteHeader">
+
+    <div class="l-menuBar">
+        <div class="l-menuMain">
+            <nav class="menuMain">
+                <div class="menuMain-content layer layer--menu">
+                    <nav class="menuMain-greedy" data-equalizer>
+                        <div class="container" data-equalizer-watch>
+                            <div class="logo">
+                                <a href="/">
+                                                                        <img src="/themes/a38/assets/images/svgs/a38-logo.svg" height="40" alt="A38">
+                                                                    </a>
+                            </div>
+                            <div class="menuMain-content-lang">
+                                                                                                <a href="https://www.a38.hu/hu/etterem" class="btn btn--lang" title="Magyar verzió">HUN</a>
+                                                                                            </div>
+
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/en/programs" class="">Events</a></li>
+                                <li><a href="https://www.a38.hu/en/exhibition-space" class="">Exhibition space</a></li>
+                            </ul>
+                            <ul class="accordion menuMain-content-items" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item  active " data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Restaurant
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                            <li class=" active "><a href="https://www.a38.hu/en/restaurant">Actual</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/weekly-menu">Weekly menu</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/menu">Menu</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/beverages">Drinks</a></li>
+                                            <li class=""><a href="https://www.a38.hu/en/restaurant/wine-list">Wine list</a></li>
+                                                                                    </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <ul class="menuMain-content-items">
+                                <li><a href="https://www.a38.hu/en/bar" class="">Bar</a></li>
+                                <li><a href="https://www.a38.hu/en/galleries" class="">Galleries</a></li>
+                                <li><a href="https://www.a38.hu/en/tv" class="">Broadcasts</a></li>
+                                <li><a href="https://blog.a38.hu/" target="_blank">Blog</a></li>
+                                <li><a href="https://www.a38.hu/en/contact" class="">Contact</a></li>
+                            </ul>
+                            <br /><br />
+                            <ul class="accordion menuMain-content-items small" data-accordion data-allow-all-closed="true">
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        About us
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/en/history">History of A38 Ship</a></li>
+                                            <li><a href="https://www.a38.hu/en/colleagues">Colleagues</a></li>
+                                            <li><a href="https://www.a38.hu/en/stagecraft">Stagecraft</a></li>
+                                            <li><a href="https://www.a38.hu/en/informations">Information</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                                <li class="accordion-item" data-accordion-item>
+                                    <a href="javascript:;" class="accordion-title" aria-selected="false" aria-expanded="false">
+                                        Services
+                                    </a>
+                                    <div class="accordion-content" data-tab-content aria-hidden="true" style="display: none;">
+                                        <ul>
+                                                                                        <li><a href="https://www.a38.hu/en/event-management">Event management and renting</a></li>
+                                            <li><a href="https://www.a38.hu/en/a38-academy">A38 Academy</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                            <br />
+                            <ul class="socialBox">
+                                <li>
+                                    <a class="socialBox-item-facebook" href="https://www.facebook.com/a38.hajo" target="_blank"><span>facebook</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-youtube" href="https://www.youtube.com/user/A38Captain" target="_blank"><span>youtube</span></a>
+                                </li>
+                                <li>
+                                    <a class="socialBox-item-instagram" href="https://www.instagram.com/a38ship/" target="_blank"><span>instagram</span></a>
+                                </li>
+                            </ul>
+
+                            <a href="#" class="menuMain-hiddenMenuToggler hidden"></a>
+
+                        </div>
+                        <header data-equalizer-watch>
+                            <a class="layer-close" href="javascript:void(0)"><span>Back</span></a>
+                        </header>
+                    </nav>
+
+                </div>
+            </nav>
+        </div>
+    </div>
+
+    <div id="header-user">
+        <header class="mobileTopBar">
+    <div class="mobileTopBar__togglerBlock">
+        <a class="js-menutoggler" href="javascript:;" onclick="A38.Layout.layerOpen('.menuMain-content', true)">
+            <span>
+                                    MENU
+                            </span>
+        </a>
+    </div>
+    <div class="mobileTopBar__logoBlock">
+        <a href="/">
+                        <img src="/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="40" alt="A38">
+                    </a>
+    </div>
+    <div class="mobileTopBar__userBlock">
+                    <a href="https://www.a38.hu/en/login" data-request="onPopupLogin" class="mobileTopBar__userBlock__login"><span>Login</span></a>
+            </div>
+    <div class="mobileTopBar__searchBlock">
+        <div id="search">
+    <div class="icon" title="Search">
+        <span>Search</span>
+    </div>
+    <div class="layer"></div>
+    <div class="container">
+        <div class="main">
+            <form method="GET" action="https://www.a38.hu/en/search">
+                <label>
+                    <input type="text" name="s" class="searchinput"
+                           placeholder="Search ..."/>
+                    <button type="button" class="clear hide-for-large" title="Clear">
+                        <span>Clear</span>
+                    </button>
+                    <span class="oc-loading"></span>
+                </label>
+                <button type="submit"
+                        class="show-for-large btn btn-small">Search</button>
+                <button type="button" class="searchclose show-for-xlarge"
+                        title="Close">
+                    <span>Close</span></button>
+            </form>
+        </div>
+    </div>
+</div>    </div>
+</header>    </div>
+
+</header>            </header>
+            <div class="l-content">
+                <!-- Content -->
+                <section id="layout-content">
+                                        <div class="container">
+    </div>                    <div class="l-content-inner">
+    <header class="mastHead">
+    <!-- Aspect Ratio 4x1 -->
+    <img class="mastHead__bg"
+         src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif"
+         data-interchange="[https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, small],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, medium],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, large],
+                           [https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.jpg, xlarge]"
+         alt="Restaurant">
+    <div class="mastHead__content">
+        <div class="l-constrained">
+            <h1 class="mastHead__title">
+                <a href="https://www.a38.hu/en/restaurant">Restaurant</a>
+            </h1>
+        </div>
+    </div>
+</header>
+    <section class="restaurantHeadNav">
+    <div class="l-constrainedGrid">
+        <nav class="restaurantNav tabNav">
+            <ul class="tabNav-menu" role="navigation">
+                <li class=" active "><a href="https://www.a38.hu/en/restaurant">Actual</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/weekly-menu">Weekly menu</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/menu">Menu</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/beverages">Drinks</a></li>
+                <li class=""><a href="https://www.a38.hu/en/restaurant/wine-list">Wine list</a></li>
+                            </ul>
+        </nav>
+    </div>
+</section>
+    <div class="l-constrainedGrid l-gutterSection">
+    <div class="row">
+        <div class="columns">
+            <!-- <h1 class=''>Étterem</h1> -->
+            <div class="row">
+                <div class="columns large-4 xlarge-3">
+                    <div class="infoCard">
+                        <figure class="infoCard__fig">
+                            <img class="infoCard__fig__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/a38-etterem.png" alt="">
+                            <a href="#" class="infoCard__fig__overlay">
+                                <img class="infoCard__fig__logo" src="https://www.a38.hu/themes/a38/assets/images/frontend/logo_a38_etterem_hu.png" alt="">
+                            </a>
+                        </figure>
+                        <div class="infoCard__caption">
+                            <p><strong>Opening hours:</strong><br>
+                                Mon-Sat 11-23h
+                            </p>
+
+
+                            <p><strong>Kitchen is open:</strong><br>
+                                Mon-Sat 12-22h
+                            </p>
+
+                            <p><strong>Reservation:</strong><br>
+                                Phone: <a href="tel:003614643946">+36-1-464-39-46</a><br>
+                                Email: <a href="mailto:etterem@a38.hu">etterem@a38.hu</a>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="columns large-8 xlarge-9">
+                                    </div>
+            </div>
+
+                        <section id="restEvents" class="restEvents l-gutterSection">
+
+                <div class="l-gutterSection">
+    <section id="exhibEvents" class="exhibEvents l-gutterSection">
+        <header class="listHeader">
+            <h2 class="listHeader__title">
+                                    Programs in the Restaurant
+                            </h2>
+        </header>
+        <ul id="eventList" class="list list--ofcards">
+
+                
+<li>
+    <a href="https://www.a38.hu/en/program/rajatszas-special-grecsokollar-hu"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/en/program/rajatszas-special-grecsokollar-hu">
+        <meta itemprop="startDate" content="2019-02-11T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                February
+                            </div>
+                            <div class="dateBox-item-day">11</div>
+                            <div >Monday <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">Restaurant</span>
+                                <link itemprop="address" content="Budapest - A38 Restaurant" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg" alt="Rájátszás Special - GreCSÓKOLlár">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/a36/acd/thumb_108199_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Rájátszás Special - GreCSÓKOLlár
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                        </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>The new series of the A38 Ship titled Beats &amp; Bites held at the A38 will feature the duo of GreCSÓKOLlár, it is the singer-songwriter László Kollár-Klemencz and poet Krisztián Grecsó.</p>
+            </div>
+                    </section>
+            </a>
+</li>    
+<li>
+    <a href="https://www.a38.hu/en/program/harcsa-veronika-gyemant-balint-duo-hu-16215"  class="event eventCard" itemscope="" itemtype="http://schema.org/MusicEvent"
+            >
+        <meta itemprop="url" content="https://www.a38.hu/en/program/harcsa-veronika-gyemant-balint-duo-hu-16215">
+        <meta itemprop="startDate" content="2019-02-25T20:00:01+01:00">
+        
+        <section class="eventCard__head">
+            <div class="eventCard__head__date">
+                <div class="dateBox dateBox--listItem ">
+                    <div class="dateBox-item dateBox-item--from">
+                        <div class="l-verticalCenter">
+                            <div>
+                                                                February
+                            </div>
+                            <div class="dateBox-item-day">25</div>
+                            <div >Monday <span class="show-for-tablet">20:00</span></div>
+                                                        <div class="dateBox-item-place show-for-tablet" itemprop="location" itemscope itemtype="http://schema.org/Place">
+                                <span itemprop="name">Restaurant</span>
+                                <link itemprop="address" content="Budapest - A38 Restaurant" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="eventCard__head__img">
+                <!-- 16x9-es képarány -->
+                                    <img class="artistCard__img" src="https://www.a38.hu/themes/a38/assets/images/frontend/spacer.gif" data-src="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg" alt="Harcsa Veronika-Gyémánt Bálint duo">
+                    <meta itemprop="image" content="https://www.a38.hu/storage/app/uploads/public/5c4/c35/772/thumb_108213_680_340_0_0_crop.jpg">
+                            </div>
+        </section>
+
+        <section class="eventCard__details ">
+            <header>
+                                <div class="eventHeader-presents">
+                                            <span>A38 Beats&amp;Bites</span>
+                                    </div>
+                                <h2 class="eventCard__details__title" itemprop="name">
+                    <div >
+                                                                        Harcsa Veronika-Gyémánt Bálint duo
+                    </div>
+                </h2>
+            </header>
+
+            <div class="eventAdditional-tags">
+                <ul class="list list--horizontal list--tag">
+                                                                <li>
+                            <span class="tag ">Jazz</span>
+                        </li>
+                                    </ul>
+            </div>
+                        <div class="eventCard__details__description" itemprop="description">
+                <p>Our new serie titled Beats &amp; Bites - which is held at our restaurant with special Danube panorama - will present the duo of singer Veronika Harcsa and guitarist Bálint Gyémánt.</p>
+            </div>
+                    </section>
+            </a>
+</li>
+        </ul>
+
+        <div id="eventListBtn">
+                    </div>
+    </section>
+</div>
+
+
+            </section>
+                    </div>
+    </div>
+</div></div>                </section>
+                <!-- Footer -->
+                <footer id="layout-footer">
+                    <footer class="l-siteFooter">
+    <div class="l-footerLogos">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-7 large-8 column">
+                    <ul class="logoList logoList--left">
+                        <li><a href="http://teh.net/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/teh-logo@2x.png" alt="Trans Europe Halles" title="Trans Europe Halles"></a></li>
+                        <li><a href="https://liveurope.eu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/liveeurope-logo@2x.png" alt="Live Europe" title="Live Europe"></a></li>
+                        <li><a href="https://ec.europa.eu/programmes/creative-europe/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/creative_europe@2x.png" alt="Creative Europe Programme" title="Creative Europe Programme"></a></li>
+                        <li class="linebreak"></li>
+                        <li><a href="https://www.mediaklikk.hu/m2/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/m2petofi-logo@2x.png" alt="m2 Petőfi" title="m2 Petőfi"></a></li>
+                        <li><a href="https://halmosbelaprogram.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/hbp-logo@2x.png" alt="Halmos Béla Program" title="Halmos Béla Program"></a></li>
+                    </ul>
+                </div>
+                <div class="small-5 large-4 column">
+                    <ul class="logoList logoList--right">
+                        <li><a href="https://www.barion.com/hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/barion-logo@2x.png" alt="Barion" title="Barion"></a></li>
+                        <li><a href="https://www.mastercard.hu/hu-hu.html" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/mastercard-logo@2x.png" alt="Mastercard" title="Mastercard"></a></li>
+                        <li><a href="https://www.visa.hu/" target="_blank"><img src="https://www.a38.hu/themes/a38/assets/images/frontend/footer-logos/visa-logo@2x.png" alt="VISA" title="VISA"></a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon">
+        <div class="l-constrainedGrid">
+            <div class="row">
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            A38 Ship Budapest
+                                                    </h2>
+                        <p>
+                                                            Petőfi bridge, Buda side
+                                                        <br>
+                            <a href="mailto:info@a38.hu">info@a38.hu</a>
+                        </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Tickets & Information
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643940">
+                                                                    +36-1-464-39-40
+                                                            </a><br>
+                                                            Mon-Sun 8-22h or until the end of events
+                                                    </p>
+                    </div>
+                </div>
+                <div class="small-12 medium-4 column">
+                    <div class="infoBox">
+                        <h2 class="infoBox-title">
+                                                            Restaurant
+                                                    </h2>
+                        <p>
+                            <a href="tel:+3614643946">
+                                                                    +36-1-464-39-46
+                                                            </a><br>
+
+                                                            Mon-Sat: 11-23h
+                                                    </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="l-footerColophon footerBottom">
+        <div class="l-constrainedGrid">
+            <div class="row align-middle">
+                <div class="small-12 medium-8 column text-left text-mobile-center">
+                    <div class="">
+                                                <a href="/"><img src="https://www.a38.hu/themes/a38/assets/images/svgs/a38-logo-wite.svg" height="30" alt="A38"></a>
+                                            </div>
+                    <br />
+                    <p class="footerPolicy">
+                                            <strong>The above hours are only directions that may differ due to weather conditions or other unforeseen circumstances.</strong><br>
+                        By entering the A38 Ship visitors consent to be filmed which may be used for public broadcast or promotional purposes.
+                                            <br/>
+                        <a href="https://www.a38.hu/en/house-rule">Rules & Policies</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/en/privacy-policy">Privacy policy</a>
+                        <span class="spacer">&bullet;</span>
+                        <a href="https://www.a38.hu/en/imprint">Imprint</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>                </footer>
+            </div>
+        </div>
+
+        <!-- Root element of PhotoSwipe. Must have class pswp. -->
+<div class="pswp" role="dialog" aria-hidden="true">
+
+    <!-- Background of PhotoSwipe.
+         It's a separate element as animating opacity is faster than rgba(). -->
+    <div class="pswp__bg"></div>
+
+    <!-- Slides wrapper with overflow:hidden. -->
+    <div class="pswp__scroll-wrap">
+
+        <!-- Container that holds slides.
+            PhotoSwipe keeps only 3 of them in the DOM to save memory.
+            Don't modify these 3 pswp__item elements, data is added later on. -->
+        <div class="pswp__container">
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+            <div class="pswp__item"></div>
+        </div>
+
+        <!-- Default (PhotoSwipeUI_Default) interface on top of sliding area. Can be changed. -->
+        <div class="pswp__ui pswp__ui--hidden">
+
+            <div class="pswp__top-bar">
+
+                <!--  Controls are self-explanatory. Order can be changed. -->
+
+                <div class="pswp__counter"></div>
+
+                <button class="pswp__button pswp__button--close" title="Close (Esc)"></button>
+
+                <button class="pswp__button pswp__button--share" title="Share"></button>
+
+                <button class="pswp__button pswp__button--fs" title="Toggle fullscreen"></button>
+
+                <button class="pswp__button pswp__button--zoom" title="Zoom in/out"></button>
+
+                <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->
+                <!-- element will get class pswp__preloader--active when preloader is running -->
+                <div class="pswp__preloader">
+                    <div class="pswp__preloader__icn">
+                      <div class="pswp__preloader__cut">
+                        <div class="pswp__preloader__donut"></div>
+                      </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="pswp__share-modal pswp__share-modal--hidden pswp__single-tap">
+                <div class="pswp__share-tooltip"></div>
+            </div>
+
+            <button class="pswp__button pswp__button--arrow--left" title="Previous (arrow left)">
+            </button>
+
+            <button class="pswp__button pswp__button--arrow--right" title="Next (arrow right)">
+            </button>
+
+            <div class="pswp__caption">
+                <div class="pswp__caption__center"></div>
+            </div>
+
+        </div>
+
+    </div>
+
+</div>
+    <!-- Scripts -->
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/plugins.js?id=fdf9b716630fc1d86d4e"></script>
+<script src="https://www.a38.hu/themes/a38/assets/dist/javascript/app.js?id=546091324477dcf15fd7"></script>
+
+<script src="/modules/system/assets/js/framework.js"></script>
+<script src="/modules/system/assets/js/framework.extras.js"></script>
+<link rel="stylesheet" property="stylesheet" href="/modules/system/assets/css/framework.extras.css">
+<!-- Load Facebook SDK for JavaScript -->
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+    var js, fjs = d.getElementsByTagName(s)[0];
+    if (d.getElementById(id)) return;
+    js = d.createElement(s); js.id = id;
+    js.src = 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.12&appId=173023849958325&autoLogAppEvents=1';
+    fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-4369219-1"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-4369219-1', {
+        'custom_map': {
+            'dimension1': 'user-login-type',
+            'dimension2': 'authenticated',
+            'dimension3': 'lang'
+        },
+        'user-login-type': 'user-no-login'
+    });
+
+    A38.Locale.init('en', 'HUF');
+    A38.Locale.setTranslations({"a38.core::lang.gallery.photo":"Photo","a38.core::lang.gallery.share_with_fb":"Share with Facebook","a38.core::lang.gallery.download":"Download photo"});
+    A38.Log.init();
+</script>
+<!-- Hotjar Tracking Code for www.a38.hu -->
+<script>
+(function(h,o,t,j,a,r){
+    h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+    h._hjSettings={hjid:346160,hjsv:6};
+    a=o.getElementsByTagName('head')[0];
+    r=o.createElement('script');r.async=1;
+    r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+    a.appendChild(r);
+})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+</script>
+<script>
+        $(document).ready(function() {
+            new A38.EventList($('#eventList'));
+        });
+    </script>
+<div id="ajax-popup" class="reveal" data-reveal data-animation-in="slide-in-up" data-animation-out="slide-out-down">
+    <div id="ajax-popup-stage">
+        <div id="ajax-popup-content" class="popup-column"></div>
+        <div id="ajax-popup-prev" class="popup-column"></div>
+        <div id="ajax-popup-next" class="popup-column"></div>
+    </div>
+</div>
+
+<script>
+    window.addEventListener("load", function(){
+        window.cookieconsent.initialise({
+            "palette": {
+                "popup": {
+                    "background": "#f8f8f8",
+                    "text": "#838391"
+                },
+                "button": {
+                    "background": "#D90016"
+                }
+            },
+            "showLink": true,
+            "theme": "classic",
+            "content": {
+                "message": "We\x20use\x20cookies\x20to\x20create\x20the\x20most\x20secure\x20and\x20effective\x20website\x20for\x20our\x20customers.\x20By\x20using\x20the\x20site\x20you\x20give\x20consent\x20to\x20this.",
+                "dismiss": "Got\x20it\x21",
+                "link": "Learn more",
+                "href": "https://www.a38.hu/en/privacy-policy"
+            }
+        })});
+</script>    </body>
+</html>

--- a/tests/a38/test_a38.py
+++ b/tests/a38/test_a38.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+
+from plugins.a38 import A38
+from tests.request_mock import RequestsMock
+from tests.resource import suite_resource, content_of
+
+
+class TestA38(TestCase):
+    def test_a38_english_url(self):
+        requests_mock = self._minimal_requests_with("a38_en.html")
+        a38 = A38(requests=requests_mock)
+
+        a38.fetch_todays_menu()
+
+        self.assertEqual("https://www.a38.hu/en/restaurant", requests_mock.url)
+
+    def test_a38_hungarian_url(self):
+        requests_mock = self._minimal_requests_with("a38_en.html")
+        a38 = A38(requests=requests_mock, lang="hu")
+
+        a38.fetch_todays_menu()
+
+        self.assertEqual("https://www.a38.hu/hu/etterem", requests_mock.url)
+
+    def test_a38_defaults_to_english(self):
+        requests_mock = self._minimal_requests_with("a38_en.html")
+        a38 = A38(requests=requests_mock, lang="unknown")
+
+        a38.fetch_todays_menu()
+
+        self.assertEqual("https://www.a38.hu/en/restaurant", requests_mock.url)
+
+    def test_a38_without_menu(self):
+        self.assert_message_for(
+            "No menu found @ A38",
+            "no_menu.html"
+        )
+
+    def test_a38_english_menu_list(self):
+        self.assert_message_for(
+            "Current A38 menu: " + " | ".join([
+                "Cauliflower soup",
+                "Fried breaded pork with corn rice",
+                "Vegetarian: Fried curd cheese with corn rice",
+                "Tiramisu"
+            ]),
+            "a38_en.html")
+
+    def test_a38_hungarian_menu_list(self):
+        menu = self.todays_menu_in("a38_hu.html")
+
+        self.assertTrue(
+            menu.startswith("Current A38 menu: Karfiolleves")
+        )
+        self.assertFalse(menu.endswith(" | "))
+
+
+    def assert_message_for(self, response, resource):
+        self.assertEqual(response, self.todays_menu_in(resource))
+
+    def todays_menu_in(self, resource):
+        a38 = A38(requests=self._minimal_requests_with(resource))
+        return a38.fetch_todays_menu()
+
+    def _minimal_requests_with(self, resource_name):
+        return RequestsMock(
+            content_of(
+                suite_resource(__file__, resource_name)
+            )
+        )

--- a/tests/request_mock.py
+++ b/tests/request_mock.py
@@ -1,0 +1,16 @@
+class RequestsMock(object):
+    def __init__(self, content):
+        self.response_content = content
+        self.url = ""
+        self.params = {}
+
+    def get(self, url, **kwargs):
+        self.url = url
+        self.params = kwargs.get("params")
+
+        return ResponseMock(self.response_content)
+
+
+class ResponseMock(object):
+    def __init__(self, content):
+        self.content = content

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -1,0 +1,10 @@
+import os
+
+
+def suite_resource(test_file, filename):
+    return os.path.join(os.path.dirname(test_file), 'resources', filename)
+
+
+def content_of(filename):
+    with open(filename) as fp:
+        return fp.read()

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -1,7 +1,8 @@
-import os
 from unittest import TestCase
 
 from plugins.youtube import YouTube
+from tests.resource import suite_resource, content_of
+from tests.request_mock import RequestsMock
 
 
 class TestYouTube(TestCase):
@@ -11,7 +12,7 @@ class TestYouTube(TestCase):
         self.assertURLEncodedQuery({"search_query": "find?this"}, "find?this")
 
     def test_youtube_content_parsing(self):
-        requests = RequestsMock()
+        requests = self._minimal_request_mock()
         youtube = YouTube(requests=requests)
 
         result = youtube.search("foobar")
@@ -22,7 +23,7 @@ class TestYouTube(TestCase):
             self.assertTrue(url.startswith("https://www.youtube.com/watch?v="))
 
     def assertURLEncodedQuery(self, expected_query, original_query):
-        requests = RequestsMock()
+        requests = self._minimal_request_mock()
         youtube = YouTube(requests=requests)
         youtube.search(original_query)
         self.assertEqual(
@@ -31,20 +32,9 @@ class TestYouTube(TestCase):
         )
         self.assertEqual(expected_query, requests.params)
 
-
-class RequestsMock(object):
-    def __init__(self, resource='foobar.html'):
-        self.result = os.path.join(os.path.dirname(__file__), 'resources', resource)
-        self.url = ""
-        self.params = {}
-
-    def get(self, url, **kwargs):
-        self.url = url
-        self.params = kwargs.get("params")
-        with open(self.result) as f:
-            return ResponseMock(f.read())
-
-
-class ResponseMock(object):
-    def __init__(self, content):
-        self.content = content
+    def _minimal_request_mock(self):
+        return RequestsMock(
+            content_of(
+                suite_resource(__file__, "foobar.html")
+            )
+        )


### PR DESCRIPTION
Notes:
* Fixed the unicode/bytes conversion error
* Removed accidental separator at the end of message caused by an extra line with space at the end of the A38 menu
* Added optional language argument.

Usage examples:
**English**
```
(14:15:42) szederz: !a38 en
(14:15:42) bot2000nick: Current A38 menu: Cauliflower soup | Fried breaded pork with corn rice | Vegetarian: Fried curd cheese with corn rice | Tiramisu
```
**Hungarian**
```
(14:27:31) szederz: !a38 hu
(14:27:31) bot2000nick: Current A38 menu: Karfiolleves | Lenmagos rántott karaj kukoricás rizzsel | Vegetáriánus: Lenmagos rántott sajt kukoricás rizzsel | Tiramisu
```
