### PR TITLE
Add unit tests for wikipedia lookup and clean up pylint warnings

### DIFF
--- a/plugins/wp_lookup.py
+++ b/plugins/wp_lookup.py
@@ -3,16 +3,15 @@ import wikipedia
 import plugin
 
 
-def wp(irc, user, target, msg):
-    cmd, title = msg.split(None, 1)
+def wikipedia_lookup(irc, _user, target, msg):
+    _cmd, title = msg.split(None, 1)
     wikipedia.set_lang('en')
 
     try:
         page = wikipedia.summary(title, sentences=1)
         page += " For more: " + wikipedia.page(title).url
-    except wikipedia.DisambiguationError as e:
-        pages = ' | '.join([s
-                            for s in e.options[:10]])
+    except wikipedia.DisambiguationError as exc:
+        pages = ' | '.join(exc.options[:10])
         results = '"%s" may refer to: %s' % (title, pages)
         irc.msg(target, results)
         return
@@ -21,9 +20,8 @@ def wp(irc, user, target, msg):
         irc.msg(target, line)
         return
 
-    page = page
     irc.msg(target, page)
 
 
-plugin.add_plugin('^!wp ', wp)
+plugin.add_plugin('^!wp ', wikipedia_lookup)
 plugin.add_help('!wp', 'Query Wikipedia. Example: !wp ozric tentacles')

--- a/tests/wp_lookup/test_wp_lookup.py
+++ b/tests/wp_lookup/test_wp_lookup.py
@@ -1,0 +1,72 @@
+from unittest import mock
+from unittest import TestCase
+
+import wikipedia
+
+from plugins import wp_lookup
+
+
+NORMAL_SEARCH_SENTENCE = 'Python is an interpreted, high-level, general-purpose programming language.'
+NORMAL_SEARCH_URL = 'https://en.wikipedia.org/wiki/Python_(programming_language)'
+
+DISAMBIGUATION_OPTIONS = [
+    'Challenger Deep',
+    'Deep Creek (Appomattox River tributary)',
+    'Deep Creek (Great Salt Lake)',
+    'Deep Creek (Mahantango Creek tributary)',
+    'Deep Creek (Mojave River tributary)',
+    'Deep Creek (Pine Creek tributary)',
+    'Deep Creek (Soque River tributary)',
+    'Deep Creek (Texas)',
+    'Deep Creek (Washington)',
+    'Deep River (Indiana)',
+    'Deep River (Iowa)',
+    'Deep River (North Carolina)',
+    'Deep River (Washington)',
+    'Deep Voll Brook'
+]
+DISAMBIGUATION_ANSWER = (
+    '"The Deep" may refer to: Challenger Deep | Deep Creek (Appomattox River tributary) | '
+    'Deep Creek (Great Salt Lake) | Deep Creek (Mahantango Creek tributary) | Deep Creek (Mojave River tributary) | '
+    'Deep Creek (Pine Creek tributary) | Deep Creek (Soque River tributary) | Deep Creek (Texas) | '
+    'Deep Creek (Washington) | Deep River (Indiana)'
+)
+
+
+class TestWikipediaLookup(TestCase):
+
+    def setUp(self):
+        self.irc = mock.MagicMock()
+        self.patch_wikipedia_summary = mock.patch('plugins.wp_lookup.wikipedia.summary')
+        self.mock_wikipedia_summary = self.patch_wikipedia_summary.start()
+        self.patch_wikipedia_page = mock.patch('plugins.wp_lookup.wikipedia.page')
+        self.mock_wikipedia_page = self.patch_wikipedia_page.start()
+
+    def tearDown(self):
+        self.patch_wikipedia_summary.stop()
+        self.patch_wikipedia_page.stop()
+
+    def test_normal_search_and_result(self):
+        self.mock_wikipedia_summary.return_value = NORMAL_SEARCH_SENTENCE
+        mock_page = mock.MagicMock()
+        mock_page.url = NORMAL_SEARCH_URL
+        self.mock_wikipedia_page.return_value = mock_page
+
+        expected_answer = '%s For more: %s' % (NORMAL_SEARCH_SENTENCE, NORMAL_SEARCH_URL)
+        wp_lookup.wp(self.irc, 'user', 'target', '!wp Python programming language')
+
+        self.irc.msg.assert_called_with('target', expected_answer)
+
+    def test_disambiguation(self):
+        self.mock_wikipedia_summary.side_effect = wikipedia.DisambiguationError('dummy', DISAMBIGUATION_OPTIONS)
+        wp_lookup.wp(self.irc, 'user', 'target', '!wp The Deep')
+        expected_answer = DISAMBIGUATION_ANSWER
+
+        self.irc.msg.assert_called_with('target', expected_answer)
+
+    def test_no_such_page(self):
+        self.mock_wikipedia_summary.side_effect = wikipedia.PageError('dummy')
+        wp_lookup.wp(self.irc, 'user', 'target', '!wp GTFO')
+        expected_answer = 'No such page: GTFO'
+
+        self.irc.msg.assert_called_with('target', expected_answer)

--- a/tests/wp_lookup/test_wp_lookup.py
+++ b/tests/wp_lookup/test_wp_lookup.py
@@ -53,20 +53,20 @@ class TestWikipediaLookup(TestCase):
         self.mock_wikipedia_page.return_value = mock_page
 
         expected_answer = '%s For more: %s' % (NORMAL_SEARCH_SENTENCE, NORMAL_SEARCH_URL)
-        wp_lookup.wp(self.irc, 'user', 'target', '!wp Python programming language')
+        wp_lookup.wikipedia_lookup(self.irc, 'user', 'target', '!wp Python programming language')
 
         self.irc.msg.assert_called_with('target', expected_answer)
 
     def test_disambiguation(self):
         self.mock_wikipedia_summary.side_effect = wikipedia.DisambiguationError('dummy', DISAMBIGUATION_OPTIONS)
-        wp_lookup.wp(self.irc, 'user', 'target', '!wp The Deep')
+        wp_lookup.wikipedia_lookup(self.irc, 'user', 'target', '!wp The Deep')
         expected_answer = DISAMBIGUATION_ANSWER
 
         self.irc.msg.assert_called_with('target', expected_answer)
 
     def test_no_such_page(self):
         self.mock_wikipedia_summary.side_effect = wikipedia.PageError('dummy')
-        wp_lookup.wp(self.irc, 'user', 'target', '!wp GTFO')
+        wp_lookup.wikipedia_lookup(self.irc, 'user', 'target', '!wp GTFO')
         expected_answer = 'No such page: GTFO'
 
         self.irc.msg.assert_called_with('target', expected_answer)

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
         {toxinidir}/tests/a38 \
         {toxinidir}/tests/spotify \
         {toxinidir}/tests/url_title \
+        {toxinidir}/tests/wp_lookup \
         {toxinidir}/tests/youtube
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py35
     py36
     py37
     py38
@@ -34,10 +33,6 @@ commands =
         {toxinidir}/tests/url_title \
         {toxinidir}/tests/wp_lookup \
         {toxinidir}/tests/youtube
-
-
-[testenv:py35]
-commands = {[unittest]commands}
 
 
 [testenv:py36]


### PR DESCRIPTION
- unit tests for wikipedia lookup plugin
- py35 tox target removed
- clean up pylint warnings from wikipedia lookup module