### PR TITLE
Catch error in !imdb plugin and fix unit test of !yt

### DIFF
--- a/plugins/imdb.py
+++ b/plugins/imdb.py
@@ -4,22 +4,24 @@ import fetcher
 import plugin
 
 BASE_URL = 'https://html.duckduckgo.com/html/?q=site:imdb.com '
-ERROR_FUN = 'That is the story of your life...'
+ERROR_FUN = 'That is the story of your life, isn\'t it?'
 
 
 def search_imdb(irc, _user, target, line):
     url = BASE_URL + line.replace('!imdb ', '')
     page = fetcher.fetch_page(url)
 
-    xpath_query = '//a[@class="result__a"]'
-    tree = html.fromstring(page)
-    elements = tree.xpath(xpath_query)
-
-    try:
-        answer = elements[0].get('href', ERROR_FUN)
-        answer += ' -- ' + elements[0].text_content()
-    except IndexError:
+    if page is None:
         answer = ERROR_FUN
+    else:
+        try:
+            xpath_query = '//a[@class="result__a"]'
+            tree = html.fromstring(page)
+            elements = tree.xpath(xpath_query)
+            answer = elements[0].get('href', ERROR_FUN)
+            answer += ' -- ' + elements[0].text_content()
+        except (IndexError, TypeError):
+            answer = ERROR_FUN
 
     irc.msg(target, answer)
 

--- a/tests/imdb/test_imdb.py
+++ b/tests/imdb/test_imdb.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 from plugins import imdb
 from tests.resource import suite_resource, content_of
 
+ERROR_ANSWER = 'That is the story of your life, isn\'t it?'
+
 
 class TestIMDB(TestCase):
 
@@ -23,9 +25,13 @@ class TestIMDB(TestCase):
 
     def test_imdb_empty_result(self):
         self.mock_fetcher.fetch_page.return_value = 'empty'
-        expected_answer = 'That is the story of your life...'
         imdb.search_imdb(self.irc, 'user', 'target', 'empty')
-        self.irc.msg.assert_called_with('target', expected_answer)
+        self.irc.msg.assert_called_with('target', ERROR_ANSWER)
+
+    def test_fetcher_got_403(self):
+        self.mock_fetcher.fetch_page.return_value = None
+        imdb.search_imdb(self.irc, 'user', 'target', 'empty')
+        self.irc.msg.assert_called_with('target', ERROR_ANSWER)
 
     @staticmethod
     def _fetch_page_resource(page):

--- a/tests/youtube/test_youtube.py
+++ b/tests/youtube/test_youtube.py
@@ -35,7 +35,7 @@ class TestYouTube(TestCase):
         youtube = YouTube(requests=requests)
         youtube.search(original_query)
         self.assertEqual(
-            "https://invidio.us/search",
+            "https://invidious.snopyta.org/search",
             requests.url
         )
         self.assertEqual(expected_query, requests.params)


### PR DESCRIPTION
- Catch empty result from fetcher
  In case the fetcher got a non-200 result when fetching the URL, it
  simply compes back with None (and prints the error to the console).
  This patch handles that case and also catches TypeError that comes
  when lxml tries to parse a received page that has some unexpected
  errors.
- Fix test of !yt command:
  The new URL broke the unit test, so replace the URL in unit test, too.
